### PR TITLE
Replace matchPaths with matchFileNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Set up Renovate with `renovate.json5`.
   ],
   "packageRules": [
     {
-      "matchPaths": ["components/**"],
+      "description": "Update dependencies per component",
+      "matchFileNames": ["components/**"],
       "additionalBranchPrefix": "{{packageFileDir}}-",
       "commitMessageSuffix": "({{packageFileDir}})",
-    }
+    },
   ],
 }
 ```


### PR DESCRIPTION
> https://docs.renovatebot.com/release-notes-for-major-versions/
> matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed

